### PR TITLE
ET-13578: add func (e Node) Press(key key.Definition)

### DIFF
--- a/node.go
+++ b/node.go
@@ -474,6 +474,10 @@ func (e Node) MustClick() {
 	panicIfError(e.Click())
 }
 
+func (e Node) Press(key key.Definition) error {
+	return e.frame.session.kb.Press(key, time.Millisecond*85)
+}
+
 func (e Node) Down() (err error) {
 	if err = e.scrollIntoView(); err != nil {
 		return err


### PR DESCRIPTION
needed for implementation
func (q Queryable) MustPress(key key.Definition) {
	err := q.node().Press(key)
	q.node().Log("MustPress", "err", err)
	if err != nil {
		panic(err)
	}
}